### PR TITLE
Fix shebang in `build.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
This makes `build.sh` work on systems without a `/bin/bash` such as NixOS.